### PR TITLE
[网页解除限制]修改部分网址

### DIFF
--- a/packages/website/public/blockList.json
+++ b/packages/website/public/blockList.json
@@ -13,10 +13,6 @@
   },
   {
     "type": "domain",
-    "url": "chuangshi.qq.com"
-  },
-  {
-    "type": "domain",
     "url": "ciweimao.com"
   },
   {

--- a/packages/website/public/blockList.json
+++ b/packages/website/public/blockList.json
@@ -21,6 +21,10 @@
   },
   {
     "type": "domain",
+    "url": "cnitpm.com"
+  },
+  {
+    "type": "domain",
     "url": "commandlinux.com"
   },
   {
@@ -34,6 +38,10 @@
   {
     "type": "domain",
     "url": "mbalib.com"
+  },
+  {
+    "type": "domain",
+    "url": "mihoyo.com"
   },
   {
     "type": "domain",
@@ -78,10 +86,6 @@
   {
     "type": "domain",
     "url": "www.cspengbo.com"
-  },
-  {
-    "type": "domain",
-    "url": "www.doc88.com"
   },
   {
     "type": "domain",


### PR DESCRIPTION
-删除 道客巴巴
该网页内容进行了加密，当前脚本暂时不支持
-删除 创世中文网
该网站使用自定义字体，无法解除限制
详见https://github.com/rxliuli/userjs/issues/23
+添加 信管网
+添加 米哈游