### PR TITLE
feat(unblock-web-restrictions): 将屏蔽列表的域名添加至源域名白名单中

### DIFF
--- a/packages/unblock-web-restrictions/dist/index.user.js
+++ b/packages/unblock-web-restrictions/dist/index.user.js
@@ -2,10 +2,11 @@
 // @name        解除网页限制
 // @description 破解禁止复制/剪切/粘贴/选择/右键菜单的网站
 // @namespace   http://github.com/rxliuli/userjs
-// @version     2.4.0
+// @version     2.4.1
 // @author      rxliuli
 // @include     *
 // @require     https://cdn.jsdelivr.net/npm/rx-util@1.9.2/dist/index.min.js
+// @connect     userjs.rxliuli.com
 // @run-at      document-start
 // @license     MIT
 // @grant       GM_getValue


### PR DESCRIPTION
好像可以防止出现“一个用户脚本试图访问跨源资源。”的弹窗，您可以试试看