### PR TITLE
feat(unblock-web-restrictions): 更新屏蔽列表

### DIFF
--- a/packages/unblock-web-restrictions/assets/blockList.json
+++ b/packages/unblock-web-restrictions/assets/blockList.json
@@ -249,6 +249,10 @@
   },
   {
     "type": "regex",
+    "url": ".*\\.cnki\\.net.*/.*/Detail"
+  },
+  {
+    "type": "regex",
     "url": ".*\\.pixnet\\.net"
   }
 ]


### PR DESCRIPTION
添加知网
形如：`*://*.cnki.net*/*/Detail*`
实例：`https://kns.cnki.net/KXReader/Detail?TIMESTAMP=637611252069189453&DBCODE=CCND&TABLEName=CCNDTEMPDAY&FileName=ZGJY20210705C021&RESULT=1&SIGN=3gMoq2DKy2Od77qdiBmyohav4rU%3d`
这样写正则应该没问题吧