### PR TITLE
ref(unblock-web-restrictions): 更新屏蔽列表

### DIFF
--- a/packages/unblock-web-restrictions/assets/blockList.json
+++ b/packages/unblock-web-restrictions/assets/blockList.json
@@ -244,6 +244,10 @@
     "url": "zhinan.sogou.com"
   },
   {
+    "type": "link",
+    "url": "https://auth.alipay.com/login/index.htm"
+  },
+  {
     "type": "linkPrefix",
     "url": "http://www.imooc.com/article/"
   },


### PR DESCRIPTION
ref:https://blog.rxliuli.com/p/9bbb456a93a8410e9d2313dcd20dc07c/
添加了支付宝登录页面，您当时提到的，该网页密码框禁止粘贴
这个要不要添加呢，添加了担心某些人说该脚本盗取支付宝的登录密码(´-﹏-`；)